### PR TITLE
Updating webpack-dev-server to 2.2.0

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@
 node_modules
 .DS_Store
 npm-debug.log
+/circle.yml

--- a/circle.yml
+++ b/circle.yml
@@ -16,4 +16,4 @@ test:
     - npm run test:circle
   post:
     - docker run -d -p 3000:3000 dashboard; cont=$(docker ps -ql) ; sleep 5
-    - wget -T 60 -S -v --retry-connrefused http://localhost:3000 -O-
+    - wget -T 60 -S -v --retry-connrefused http://localhost:3000 -O- ; docker logs $cont

--- a/circle.yml
+++ b/circle.yml
@@ -15,5 +15,5 @@ test:
   override:
     - npm run test:circle
   post:
-    - docker run -d -p 3000:3000 dashboard; sleep 10
+    - docker run -d -p 3000:3000 dashboard; cont=$(docker ps -ql) ; sleep 5
     - wget -T 60 -S -v --retry-connrefused http://localhost:3000 -O-

--- a/circle.yml
+++ b/circle.yml
@@ -15,6 +15,4 @@ test:
   override:
     - npm run test:circle
   post:
-    - docker run -d -p 3000:3000 dashboard; cont=$(docker ps -ql) ; sleep 5
-    - wget -T 60 -S -v --retry-connrefused http://localhost:3000 -O- ; docker logs $cont
-    - wget -T 30 --tries=10 -S -v --retry-connrefused http://localhost:3000 -O- ; docker logs $cont
+    - docker run -d -p 3000:3000 dashboard; cont=$(docker ps -ql) ; sleep 5 ; wget -T 30 --tries=10 -S -v --retry-connrefused http://localhost:3000 -O- ; docker logs $cont

--- a/circle.yml
+++ b/circle.yml
@@ -17,3 +17,4 @@ test:
   post:
     - docker run -d -p 3000:3000 dashboard; cont=$(docker ps -ql) ; sleep 5
     - wget -T 60 -S -v --retry-connrefused http://localhost:3000 -O- ; docker logs $cont
+    - wget -T 30 --tries=10 -S -v --retry-connrefused http://localhost:3000 -O- ; docker logs $cont


### PR DESCRIPTION

Please update [webpack-dev-server](https://npmjs.org/package/webpack-dev-server) to version 2.2.0.

If this passes your tests you can merge it in.  If not please use this branch for changes.

 * [```7e18f6a```](https://github.com/webpack/webpack-dev-server/commit/7e18f6a733162af022423db68a519b5186bdd6e4) ```2.2.0```
 * [```e9dd0ed```](https://github.com/webpack/webpack-dev-server/commit/e9dd0ed2601f80ab1a55429737b8576555c0829c) ```Upgrade webpack dependency```
 * [```cae704f```](https://github.com/webpack/webpack-dev-server/commit/cae704f56f4517be8a7747f88df4aac11cd84110) ```Update README to new standard```
 * [```d560695```](https://github.com/webpack/webpack-dev-server/commit/d560695c31db5e3e68e40b46b10c04c277de451c) ```Fix broken test after webpack update```
 * [```84a98ad```](https://github.com/webpack/webpack-dev-server/commit/84a98ad2eb15b19bfb5b84b9c70535c76bbc222c) ```update webpack dev dependency```
 * [```a947336```](https://github.com/webpack/webpack-dev-server/commit/a947336b272d677e1a7d933c7d81705c8edc9be3) ```Refactor to ES6```
 * [```fb74672```](https://github.com/webpack/webpack-dev-server/commit/fb74672033aec4af1a23590b65a971d48e8ee7fb) ```Bring eslint config in line with webpack/webpack```
 * [```2f9ac82```](https://github.com/webpack/webpack-dev-server/commit/2f9ac82069db086efc16356141c7f1579eeaa651) ```Make Travis run Node.js v4 and v6```
 * [```bbcca86```](https://github.com/webpack/webpack-dev-server/commit/bbcca86c4b50a23a3796acd34a86cdd7eac0fbaa) ```Require Node.js v4.7 or higher```
 * [```fcf5f3c```](https://github.com/webpack/webpack-dev-server/commit/fcf5f3cfbe7cf7bb629e801cc200358c792df017) ```(fix) proxy config with bypass and without target &hellip;```
 * [```00bdcd5```](https://github.com/webpack/webpack-dev-server/commit/00bdcd5de0487ea31263c39abd748b2d6e190a31) ```2.2.0-rc.0```
 * [```cffd387```](https://github.com/webpack/webpack-dev-server/commit/cffd38745c593942d6ddfb8ca5b799c5e342a6f6) ```update webpack-dev-middleware dep```
 * [```1adb818```](https://github.com/webpack/webpack-dev-server/commit/1adb818c743209b69082362f3d9191a83231dc80) ```Allow webpack 2 rc```
 * [```658280d```](https://github.com/webpack/webpack-dev-server/commit/658280d8c497053877aec50974766d66d9b9def1) ```Update License to match with webpack/webpack```
 * [```1f60309```](https://github.com/webpack/webpack-dev-server/commit/1f603090a7ddcb7bd439fda11a2a33dd86e95473) ```2.1.0-beta.12```


See the full [change log](https://github.com/webpack/webpack-dev-server/compare/bf741ce8143dc61e3e946536d1b1b42d3ed16355...7e18f6a733162af022423db68a519b5186bdd6e4) for everything that changed in this release.