### PR TITLE
Remove babel loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "@storybook/addon-viewport": "4.1.11",
     "@storybook/addons": "4.1.11",
     "@storybook/react": "4.1.11",
-    "babel-loader": "8.0.4",
     "babel-plugin-relay": "2.0.0",
     "enzyme": "3.8.0",
     "enzyme-adapter-react-16": "1.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2939,7 +2939,7 @@ babel-traverse@^6.0.0, babel-traverse@^6.18.0, babel-traverse@^6.26.0:
     invariant "^2.2.2"
     lodash "^4.17.4"
 
-babel-types@^6.0.0, babel-types@^6.18.0, babel-types@^6.24.1, babel-types@^6.26.0:
+babel-types@^6.0.0, babel-types@^6.18.0, babel-types@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
   integrity sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=


### PR DESCRIPTION
the babel-loader dependency is obsolete and already a dependency of 
react-scripts and @storybook/react