### PR TITLE
replace jsx based router-config with router conf by object object

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@babel/node": "7.8.7",
     "bulma": "0.8.0",
     "github-api": "lowsky/github-api#supportInUsedInBrowser",
+    "react-router-config": "5.1.1",
     "react-scripts": "3.4.1",
     "whatwg-fetch": "3.0.0"
   },

--- a/src/relay/main.tsx
+++ b/src/relay/main.tsx
@@ -42,8 +42,8 @@ const GithubQuery = graphql`
 const RelayRoot = ({ match }) => (
     <QueryRenderer
         variables={{
-            userName: match.params.userName,
-            repoName: match.params.repoName,
+            userName: match?.params?.userName,
+            repoName: match?.params?.repoName,
         }}
         environment={environment}
         query={GithubQuery}

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,5 +1,6 @@
 import React, { lazy, Suspense } from 'react';
-import { BrowserRouter as Router, Redirect, Route, Switch } from 'react-router-dom';
+import { BrowserRouter as Router } from 'react-router-dom';
+import { renderRoutes } from 'react-router-config';
 
 import IndexPageMain from './index/IndexPage';
 import { NavBar } from './components/NavBar';
@@ -7,6 +8,49 @@ import { Spinner } from './components/Spinner';
 
 const RelayMain = lazy(() => import('./relay/main'));
 const RestfulMain = lazy(() => import('./restinpeace/restful'));
+
+const WarningMissingURLParams = (
+    <div className="jumbo has-text-weight-bold has-text-danger has-text-centered">
+        Warning, need full <i>user</i> and <i>repo</i> info as part orf url!
+    </div>
+);
+const routes = [
+    {
+        path: '/relay/:userName/:repoName',
+        exact: true,
+        _component: (props) => {
+            console.log(props);
+            return <div>{`${props.match.params.userName}`}</div>;
+        },
+        component: ({ match }) => <RelayMain {...match.params} />,
+    },
+    {
+        path: '/relay',
+        component: () => WarningMissingURLParams,
+    },
+    {
+        path: '/restful/:userName/:repoName',
+        // eslint-disable-next-line react/prop-types
+        component: ({ match: { params } }) => <RestfulMain {...params} />,
+    },
+    {
+        path: '/restful',
+        component: () => WarningMissingURLParams,
+    },
+    {
+        path: '/',
+        component: IndexPageMain,
+    },
+    {
+        path: '/home',
+        component: (props) => (
+            <div>
+                {JSON.stringify(props)}
+                <IndexPageMain {...props} />
+            </div>
+        ),
+    },
+];
 
 const MainPage = () => (
     <Router>
@@ -19,19 +63,7 @@ const MainPage = () => (
             </header>
 
             <main>
-                <Suspense fallback={<Spinner />}>
-                    <Switch>
-                        <Redirect exact from="/" to="/home" />
-                        <Route exact path="/home" component={IndexPageMain} />
-                        <Route path="/relay/:userName/:repoName" component={RelayMain} />
-                        <Route
-                            path="/restful/:userName/:repoName"
-                            component={({ match: { params } }) => <RestfulMain {...params} />}
-                        />
-                        <Redirect from="/relay" to="/relay/lowsky/dashboard" />
-                        <Redirect from="/restful" to="/restful/lowsky/dashboard" />
-                    </Switch>
-                </Suspense>
+                <Suspense fallback={<Spinner />}>{renderRoutes(routes)}</Suspense>
             </main>
         </div>
     </Router>


### PR DESCRIPTION
from: https://github.com/ReactTraining/react-router/blob/master/packages/react-router-config/README.md

Routes are objects with the same properties as a <Route> with a couple differences:

* the only render prop it accepts is component (no render or children)
* introduces the routes key for sub routes
* Consumers are free to add any additional props they'd like to a route, you can access props.route inside the component, this object is a reference to the object used to render and match.
* accepts key prop to prevent remounting component when transition was made from route with the same component and same key prop
